### PR TITLE
Improve check for bundler presence.

### DIFF
--- a/mac
+++ b/mac
@@ -28,6 +28,7 @@ append_to_file() {
   fi
 }
 
+# shellcheck disable=SC2154
 trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
 
 set -e
@@ -85,7 +86,7 @@ brew_tap() {
 }
 
 gem_install_or_update() {
-  if gem list "$1" --installed > /dev/null; then
+  if gem list "$1" | grep "^$1 ("; then
     fancy_echo "Updating %s ..." "$1"
     gem update "$@"
   else
@@ -99,12 +100,14 @@ brew_cask_expand_alias() {
 }
 
 brew_cask_is_installed() {
-  local NAME=$(brew_cask_expand_alias "$1")
+  local NAME
+  NAME=$(brew_cask_expand_alias "$1")
   brew cask list -1 | grep -Fqx "$NAME"
 }
 
 app_is_installed() {
-  local app_name=$(echo "$1" | cut -d'-' -f1)
+  local app_name
+  app_name=$(echo "$1" | cut -d'-' -f1)
   find /Applications -iname "$app_name*" -maxdepth 1 | egrep '.*' > /dev/null
 }
 


### PR DESCRIPTION
Up until version 1.26.11, RVM installed `bundler` by default, but now it doesn't anymore. However, RVM still comes with `rubygems-bundler` and `bundler-unload`, and running `gem list bundler --installed` while those gems are present will return `true`, erroneously leading the `gem_install_or_update` function to believe that bundler was already installed.

By using a regular expression, we look for a gem name that starts with bundler, followed by a space and an opening parenthesis, which will properly detect whether or not bundler is installed.

Also includes shellcheck fixes to make the tests pass.

Closes #1.