### PR TITLE
replace cat with less -N

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ script respectively:
 
 ```sh
 curl --remote-name https://raw.githubusercontent.com/monfresh/laptop/master/mac
-cat mac
+less -N mac
 bash mac 2>&1 | tee ~/laptop.log && source ~/.rvm/scripts/rvm
 ```
 


### PR DESCRIPTION
this way it should be easier to read - `less` should be installed everywhere so also should work, not sure if there should be a note in `mac` to exit the `less` view with `q`