### PR TITLE
Install Bundler globally

### DIFF
--- a/mac
+++ b/mac
@@ -153,14 +153,14 @@ append_to_file "$HOME/.gemrc" 'gem: --no-document'
 if ! command -v rbenv >/dev/null; then
   if ! command -v rvm >/dev/null; then
     fancy_echo 'Installing RVM and the latest Ruby...'
-    curl -L https://get.rvm.io | bash -s stable --ruby --auto-dotfiles --autolibs=enable
+    curl -L https://get.rvm.io | bash -s stable --ruby --auto-dotfiles --autolibs=enable --with-gems="bundler"
     . ~/.rvm/scripts/rvm
   else
     local_version="$(rvm -v 2> /dev/null | awk '$2 != ""{print $2}')"
     latest_version="$(curl -s https://raw.githubusercontent.com/wayneeseguin/rvm/stable/VERSION)"
     if [ "$local_version" != "$latest_version" ]; then
       fancy_echo 'Upgrading RVM...'
-      rvm get stable --auto-dotfiles --autolibs=enable
+      rvm get stable --auto-dotfiles --autolibs=enable --with-gems="bundler"
     else
       fancy_echo "Already using the latest version of RVM. Skipping..."
     fi


### PR DESCRIPTION
So that it is available in all gemsets. Otherwise, if you clone
a repo that uses a `.ruby-gemset`, bundler won't be automatically
available and `bundle install` will fail. Beginners might not
know they can `gem install bundler` to fix the issue.
Since Bundler is widely used, it makes sense to install it in the
global gemset.

RVM stopped shipping with bundler, but we can make it install
bundler in the global gemset by passing the `--with-gems` flag.