### PR TITLE
Install bundler in global gemset

### DIFF
--- a/mac
+++ b/mac
@@ -23,7 +23,7 @@ append_to_file() {
     fi
   fi
 
-  if ! grep -Fqs "$text" "$file"; then
+  if ! grep -qs "^$text$" "$file"; then
     printf "\n%s\n" "$text" >> "$file"
   fi
 }
@@ -193,6 +193,7 @@ if [ -f "$HOME/.laptop.local" ]; then
 fi
 
 append_to_file "$HOME/.rvmrc" 'rvm_auto_reload_flag=2'
+append_to_file "$HOME/.rvm/gemsets/global.gems" 'bundler'
 
 # display pwd in orange, current ruby version or gemset in green,
 # and set prompt character to $


### PR DESCRIPTION
RVM stopped shipping with Bundler, which means that if you clone
a repo that uses a `.ruby-gemset`, or if you install a new version
of Ruby, or update to a new version of RVM, Bundler won't be
automatically available, and bundle install will fail.

Beginners might not know they can `gem install bundler` to fix the
issue, and even if you did know, having to type that each time is
annoying. Since Bundler is widely used, it makes sense to install
it in the global gemset so that it is available at any time.

I also had to fix the `append_to_file` function to look for exact
string matches. Otherwise, it would treat "rubygems-bundler" as a
match for "bundler" and won't add it to the global gemset.