### PR TITLE
Replace Qt with PhantomJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ What it sets up
 * [Homebrew Cask] for quickly installing Mac apps from the command line
 * [Homebrew Services] so you can easily stop, start, and restart services
 * [hub] for interacting with the GitHub API
+* [PhantomJS] for headless website testing
 * [Postgres] for storing relational data
-* [Qt] for headless JavaScript testing via Capybara Webkit
 * [RVM] for managing Ruby versions (includes the latest [Ruby])
 * [Sublime Text 3] for coding all the things
 * [Zsh] as your shell
@@ -84,8 +84,8 @@ What it sets up
 [Homebrew Cask]: http://caskroom.io/
 [Homebrew Services]: https://github.com/gapple/homebrew-services
 [hub]: https://github.com/github/hub
+[PhantomJS]: http://phantomjs.org/
 [Postgres]: http://www.postgresql.org/
-[Qt]: http://qt-project.org/
 [Ruby]: https://www.ruby-lang.org/en/
 [RVM]: https://github.com/wayneeseguin/rvm
 [Sublime Text 3]: http://www.sublimetext.com/3

--- a/mac
+++ b/mac
@@ -142,7 +142,7 @@ brew_install_or_upgrade 'postgresql'
 fancy_echo 'Restarting postgres...'
 brew services restart postgresql
 
-brew_install_or_upgrade 'qt'
+brew_install_or_upgrade 'phantomjs'
 
 brew_install_or_upgrade 'hub'
 # shellcheck disable=SC2016


### PR DESCRIPTION
Why:
The original reason for including Qt was to provide support for Ruby apps that are using capybara-webkit. However, capybara-webkit will soon require Qt5 to be installed, but Qt5 requires the full Xcode package.

I don't think it's possible to automate the installation of Xcode, and even if it were possible, I wouldn't want to force everyone to download a multi-gigabyte file. Instead, it makes more sense to recommend PhantomJS and Poltergeist (for Ruby apps), which works just as well as capybara-webkit.