### PR TITLE
Allow phantomjs to be installed on El Capitan

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ What it sets up
 * [Homebrew Cask] for quickly installing Mac apps from the command line
 * [Homebrew Services] so you can easily stop, start, and restart services
 * [hub] for interacting with the GitHub API
-* [PhantomJS] for headless website testing (unless on El Capitan, due to
-[this bug](https://github.com/Homebrew/homebrew/issues/42249))
+* [PhantomJS] for headless website testing
 * [Postgres] for storing relational data
 * [RVM] for managing Ruby versions (includes the latest [Ruby])
 * [Sublime Text 3] for coding all the things

--- a/mac
+++ b/mac
@@ -150,11 +150,7 @@ brew_install_or_upgrade 'postgresql'
 fancy_echo 'Restarting postgres...'
 brew services restart postgresql
 
-# PhantomJS doesn't support El Capitan yet
-# https://github.com/Homebrew/homebrew/issues/42249
-if ! sw_vers -productVersion | grep -q "^10\.11"; then
-  brew_install_or_upgrade 'phantomjs'
-fi
+brew_install_or_upgrade 'phantomjs'
 
 brew_install_or_upgrade 'hub'
 # shellcheck disable=SC2016


### PR DESCRIPTION
phantomjs via Homebrew is now supported on El Capitan