### PR TITLE
Use `brew bundle` instead of custom functions

### DIFF
--- a/.laptop.local
+++ b/.laptop.local
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-# brew_cask_install 'atom'
-# brew_cask_install 'cloud'
-# brew_cask_install 'firefox'
-# brew_cask_install 'iterm2'
+fancy_echo "Running your customizations from ~/.laptop.local ..."
+
+brew bundle --file=- <<EOF
+cask 'atom'
+cask 'cloud'
+cask 'firefox'
+cask 'iterm2'
+EOF

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,19 @@
+cask_args appdir: '/Applications'
+
+brew 'git'
+
+brew 'heroku-toolbelt'
+
+tap 'homebrew/services'
+
+brew 'postgresql'
+
+brew 'phantomjs'
+
+brew 'hub'
+
+tap 'caskroom/cask'
+tap 'caskroom/versions'
+cask 'flux'
+cask 'github-desktop'
+cask 'sublime-text'

--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ keyboard shortcut for invoking Spotlight is `command-Space`. Once Spotlight
 is up, just start typing the first few letters of the app you are looking for,
 and once it appears, press `return` to launch it.
 
-In your Terminal window, copy and paste each of these two commands one at a
-time, then press `return` after each one to download and execute the
-script, respectively:
+In your Terminal window, copy and paste each of these three commands one at a
+time, then press `return` after each one. The first two commands download the
+files the script needs to run, and the third command executes the script.
 
 ```sh
 curl --remote-name https://raw.githubusercontent.com/monfresh/laptop/master/mac
+curl --remote-name https://raw.githubusercontent.com/monfresh/laptop/master/Brewfile
 bash mac 2>&1 | tee ~/laptop.log && source ~/.rvm/scripts/rvm
 ```
 
@@ -53,7 +54,7 @@ If you don't already have it installed, GitHub for Mac will launch
 automatically at the end of the script so you can set up everything you'll
 need to push code to GitHub.
 
-Once the script is done, quit and relaunch Terminal.
+**Once the script is done, quit and relaunch Terminal.**
 
 More [detailed instructions with a video][video] are available in the Wiki.
 
@@ -92,7 +93,7 @@ What it sets up
 [Heroku Toolbelt]: https://toolbelt.heroku.com/
 [Homebrew]: http://brew.sh/
 [Homebrew Cask]: http://caskroom.io/
-[Homebrew Services]: https://github.com/gapple/homebrew-services
+[Homebrew Services]: https://github.com/Homebrew/homebrew-services
 [hub]: https://github.com/github/hub
 [PhantomJS]: http://phantomjs.org/
 [Postgres]: http://www.postgresql.org/
@@ -143,8 +144,8 @@ any of the 256 possible [Xterm colors](http://upload.wikimedia.org/wikipedia/com
 Save the file, then open a new Terminal window or tab to see the changes.
 
 
-Customize in `~/.laptop.local`
-------------------------------
+Customize in `~/.laptop.local` and `Brewfile`
+---------------------------------------------
 ```sh
 # Go to your OS X user's root directory
 cd ~
@@ -158,8 +159,7 @@ subl .laptop.local
 
 Your `~/.laptop.local` is run at the end of the `mac` script.
 Put your customizations there. You can use the `.laptop.local` you downloaded
-above to get started. It lets you install the following tools
-(commented out by default):
+above to get started. It lets you install the following tools:
 
 * [Atom] - GitHub's open source text editor
 * [CloudApp] for sharing screenshots and making an animated GIF from a video
@@ -171,27 +171,44 @@ above to get started. It lets you install the following tools
 [Firefox]: https://www.mozilla.org/en-US/firefox/new/
 [iTerm2]: http://iterm2.com/
 
-To install any of the above tools, uncomment them from `.laptop.local` by
-removing the `#`. For example, to install CloudApp, your `.laptop.local`
-should look like this:
-
-```sh
-#!/bin/sh
-
-# brew_cask_install 'atom'
-brew_cask_install 'cloud'
-# brew_cask_install 'firefox'
-# brew_cask_install 'iterm2'
-```
-
 Write your customizations such that they can be run safely more than once.
 See the `mac` script for examples.
 
-Laptop functions such as `fancy_echo`, `brew_install_or_upgrade`,
-`gem_install_or_update`, and `brew_cask_install` can be used in your
-`~/.laptop.local`.
+Laptop functions such as `fancy_echo`, and `gem_install_or_update` can be used
+in your `~/.laptop.local`.
 
+Editing the `Brewfile`
+----------------------
+Most of what the script installs is listed in the `Brewfile`. If you don't want
+the script to install certain tools, you can remove them from the `Brewfile`.
 
+How to manage background services (such as Postgres)
+----------------------------------------------------------
+The script does not automatically launch these services after installation
+because you might not need or want them to be running. With Homebrew Services,
+starting, stopping, or restarting these services is as easy as:
+
+```
+brew services start|stop|restart [name of service]
+```
+
+For example:
+
+```
+brew services start postgresql
+```
+
+To see a list of all installed services:
+
+```
+brew services list
+```
+
+To start all services at once:
+
+```
+brew services start --all
+```
 
 Credits
 -------

--- a/mac
+++ b/mac
@@ -52,37 +52,8 @@ case "$SHELL" in
     ;;
 esac
 
-brew_install_or_upgrade() {
-  if brew_is_installed "$1"; then
-    if brew_is_upgradable "$1"; then
-      fancy_echo "Upgrading %s ..." "$1"
-      brew upgrade "$@"
-    else
-      fancy_echo "Already using the latest version of %s. Skipping ..." "$1"
-    fi
-  else
-    fancy_echo "Installing %s ..." "$1"
-    brew install "$@"
-  fi
-}
-
 brew_is_installed() {
   brew list -1 | grep -Fqx "$1"
-}
-
-brew_is_upgradable() {
-  ! brew outdated --quiet "$1" >/dev/null
-}
-
-brew_tap_is_installed() {
-  brew tap | grep -Fqx "$1"
-}
-
-brew_tap() {
-  if ! brew_tap_is_installed "$1"; then
-    fancy_echo "Tapping $1..."
-    brew tap "$1" 2> /dev/null
-  fi
 }
 
 gem_install_or_update() {
@@ -95,29 +66,10 @@ gem_install_or_update() {
   fi
 }
 
-brew_cask_expand_alias() {
-  brew cask info "$1" 2>/dev/null | head -1 | awk '{gsub(/:/, ""); print $1}'
-}
-
-brew_cask_is_installed() {
-  local NAME
-  NAME=$(brew_cask_expand_alias "$1")
-  brew cask list -1 | grep -Fqx "$NAME"
-}
-
 app_is_installed() {
   local app_name
   app_name=$(echo "$1" | cut -d'-' -f1)
   find /Applications -iname "$app_name*" -maxdepth 1 | egrep '.*' > /dev/null
-}
-
-brew_cask_install() {
-  if app_is_installed "$1" || brew_cask_is_installed "$1"; then
-    fancy_echo "$1 is already installed. Skipping..."
-  else
-    fancy_echo "Installing $1..."
-    brew cask install "$@"
-  fi
 }
 
 if ! command -v brew >/dev/null; then
@@ -131,6 +83,13 @@ else
   fancy_echo "Homebrew already installed. Skipping ..."
 fi
 
+# Remove brew-cask since it is now installed as part of brew tap caskroom/cask.
+# See https://github.com/caskroom/homebrew-cask/releases/tag/v0.60.0
+if brew_is_installed 'brew-cask'; then
+  brew uninstall --force 'brew-cask'
+  brew untap caskroom/versions
+fi
+
 fancy_echo "Updating Homebrew formulas ..."
 brew update
 
@@ -142,17 +101,9 @@ else
   echo "Review the Homebrew messages to see if any action is needed."
 fi
 
-brew_install_or_upgrade 'git'
+fancy_echo "Installing formulas and casks from the Brewfile ..."
+brew bundle
 
-brew_tap 'gapple/services'
-
-brew_install_or_upgrade 'postgresql'
-fancy_echo 'Restarting postgres...'
-brew services restart postgresql
-
-brew_install_or_upgrade 'phantomjs'
-
-brew_install_or_upgrade 'hub'
 # shellcheck disable=SC2016
 append_to_file "$HOME/.zshrc" 'eval "$(hub alias -s)"'
 
@@ -161,7 +112,7 @@ append_to_file "$HOME/.gemrc" 'gem: --no-document'
 if ! command -v rbenv >/dev/null; then
   if ! command -v rvm >/dev/null; then
     fancy_echo 'Installing RVM and the latest Ruby...'
-    curl -L https://get.rvm.io | bash -s stable --ruby --auto-dotfiles --autolibs=enable
+    curl -L https://get.rvm.io | bash -s head --ruby --auto-dotfiles --autolibs=enable
     . ~/.rvm/scripts/rvm
   else
     local_version="$(rvm -v 2> /dev/null | awk '$2 != ""{print $2}')"
@@ -181,20 +132,10 @@ gem update --system
 gem_install_or_update 'bundler'
 
 fancy_echo "Configuring Bundler ..."
-  number_of_cores=$(sysctl -n hw.ncpu)
-  bundle config --global jobs $((number_of_cores - 1))
+number_of_cores=$(sysctl -n hw.ncpu)
+bundle config --global jobs $((number_of_cores - 1))
 
-brew_install_or_upgrade 'heroku-toolbelt'
-
-brew_tap 'caskroom/cask'
-
-brew_install_or_upgrade 'brew-cask'
-
-brew_tap 'caskroom/versions'
-
-brew_cask_install 'flux'
-brew_cask_install 'github-desktop'
-brew_cask_install 'sublime-text3'
+fancy_echo '...Finished Ruby installation checks.'
 
 if [ -f "$HOME/.laptop.local" ]; then
   . "$HOME/.laptop.local"


### PR DESCRIPTION
**Why**:
Homebrew-bundle does what the custom functions used to do. It also allows us to
use a Brewfile, which makes it easier to see in one place what gets installed,
and makes it easier to customize that list.

As part of moving to a Brewfile, I also removed the directives to restart
Postgres. Given that the script installs Homebrew services,
managing services manually is very easy, and the user can choose when to start
them.