### PR TITLE
Replace RVM with chruby and ruby-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ What it sets up
 ---------------
 
 * [Bundler] for managing Ruby gems
+* [chruby] for managing [Ruby] versions
 * [Flux] for adjusting your Mac's display color so you can sleep better
 * [GitHub Desktop] for setting up your SSH keys automatically
 * [Heroku Toolbelt] for deploying and managing Heroku apps
@@ -84,11 +85,12 @@ What it sets up
 * [hub] for interacting with the GitHub API
 * [PhantomJS] for headless website testing
 * [Postgres] for storing relational data
-* [RVM] for managing Ruby versions (includes the latest [Ruby])
+* [ruby-install] for installing different versions of Ruby
 * [Sublime Text 3] for coding all the things
 * [Zsh] as your shell
 
 [Bundler]: http://bundler.io/
+[chruby]: https://github.com/postmodern/chruby
 [Flux]: https://justgetflux.com/
 [GitHub Desktop]: https://desktop.github.com/
 [Heroku Toolbelt]: https://toolbelt.heroku.com/
@@ -99,7 +101,7 @@ What it sets up
 [PhantomJS]: http://phantomjs.org/
 [Postgres]: http://www.postgresql.org/
 [Ruby]: https://www.ruby-lang.org/en/
-[RVM]: https://github.com/wayneeseguin/rvm
+[ruby-install]: https://github.com/postmodern/ruby-install
 [Sublime Text 3]: http://www.sublimetext.com/3
 [Zsh]: http://www.zsh.org/
 

--- a/mac
+++ b/mac
@@ -116,6 +116,16 @@ app_is_installed() {
   find /Applications -iname "$app_name*" -maxdepth 1 | egrep '.*' > /dev/null
 }
 
+latest_installed_ruby() {
+  find "$HOME/.rubies" -maxdepth 1 -name 'ruby-*' | tail -n1 | egrep -o '\d+\.\d+\.\d+'
+}
+
+switch_to_latest_ruby() {
+  # shellcheck disable=SC1091
+  . /usr/local/share/chruby/chruby.sh
+  chruby "ruby-$(latest_installed_ruby)"
+}
+
 # shellcheck disable=SC2016
 append_to_file "$shell_file" 'export PATH="$HOME/.bin:$PATH"'
 
@@ -156,20 +166,41 @@ append_to_file "$shell_file" 'eval "$(hub alias -s)"'
 
 append_to_file "$HOME/.gemrc" 'gem: --no-document'
 
-if ! command -v rbenv >/dev/null; then
-  if ! command -v rvm >/dev/null; then
-    fancy_echo 'Installing RVM and the latest Ruby...'
-    curl -L https://get.rvm.io | bash -s head --ruby --auto-dotfiles --autolibs=enable
-    # shellcheck source=/dev/null
-    . ~/.rvm/scripts/rvm
+if command -v rbenv >/dev/null || command -v rvm >/dev/null; then
+  fancy_echo 'We recommend chruby and ruby-install over RVM or rbenv'
+else
+  if ! brew_is_installed "chruby"; then
+    fancy_echo 'Installing chruby, ruby-install, and the latest Ruby...'
+
+    brew bundle --file=- <<EOF
+    brew 'chruby'
+    brew 'ruby-install'
+EOF
+
+    append_to_file "$shell_file" 'source /usr/local/share/chruby/chruby.sh'
+    append_to_file "$shell_file" 'source /usr/local/share/chruby/auto.sh'
+
+    ruby-install ruby
+
+    append_to_file "$shell_file" "chruby ruby-$(latest_installed_ruby)"
+
+    switch_to_latest_ruby
   else
-    local_version="$(rvm -v 2> /dev/null | awk '$2 != ""{print $2}')"
-    latest_version="$(curl -s https://raw.githubusercontent.com/wayneeseguin/rvm/stable/VERSION)"
-    if [ "$local_version" != "$latest_version" ]; then
-      fancy_echo 'Upgrading RVM...'
-      rvm get stable --auto-dotfiles --autolibs=enable --with-gems="bundler"
+    brew bundle --file=- <<EOF
+    brew 'chruby'
+    brew 'ruby-install'
+EOF
+    fancy_echo 'Checking if a newer version of Ruby is available...'
+    switch_to_latest_ruby
+
+    ruby-install --latest > /dev/null
+    latest_stable_ruby="$(cat < "$HOME/.cache/ruby-install/ruby/stable.txt" | tail -n1)"
+
+    if ! [ "$latest_stable_ruby" = "$(latest_installed_ruby)" ]; then
+      fancy_echo "Installing latest stable Ruby version: $latest_stable_ruby"
+      ruby-install ruby
     else
-      fancy_echo "Already using the latest version of RVM. Skipping..."
+      fancy_echo 'You have the latest version of Ruby'
     fi
   fi
 fi
@@ -190,17 +221,45 @@ if [ -f "$HOME/.laptop.local" ]; then
   . "$HOME/.laptop.local"
 fi
 
-append_to_file "$HOME/.rvmrc" 'rvm_auto_reload_flag=2'
-append_to_file "$HOME/.rvm/gemsets/global.gems" 'bundler'
+no_prompt_customizations_in_shell_file() {
+  ! grep -qs -e ".oh-my-zsh" -e "PS1=" -e "precmd" -e "PROMPT=" "$shell_file"
+}
 
-# display pwd in orange, current ruby version or gemset in green,
-# and set prompt character to $
-# shellcheck disable=SC2016
-append_to_file "$shell_file" 'precmd () { PS1="%{%F{166}%}[%~] %{%F{65}%}$(rvm-prompt) %{%f%}$ " }'
+no_zsh_frameworks() {
+  [ -f "$HOME/.oh-my-zsh" ] && [ -f "$HOME/.zpresto" ] && [ -f "$HOME/.zim" ] && [ -f "$HOME/.zplug" ]
+}
 
-# display directories and files in different colors when running ls
-append_to_file "$shell_file" 'export CLICOLOR=1;'
-append_to_file "$shell_file" 'export LSCOLORS=exfxcxdxbxegedabagacad;'
+if [ -z "$CI" ] && no_zsh_frameworks && no_prompt_customizations_in_shell_file; then
+  echo -n "Would you like to customize your prompt to display the current directory and ruby version? [y/n]: "
+  read -r -n 1 response
+  if [ "$response" = "y" ]; then
+    if ! grep -qs "prompt_ruby_info()" "$shell_file"; then
+      cat <<EOT >> "$shell_file"
+
+  prompt_ruby_info() {
+    if [ -f ".ruby-version" ]; then
+      cat .ruby-version
+    fi
+  }
+EOT
+    fi
+    # shellcheck disable=SC2016
+    append_to_file "$shell_file" 'GREEN=$(tput setaf 65)'
+    # shellcheck disable=SC2016
+    append_to_file "$shell_file" 'ORANGE=$(tput setaf 166)'
+    # shellcheck disable=SC2016
+    append_to_file "$shell_file" 'NORMAL=$(tput sgr0)'
+    # display pwd in orange, current ruby version in green,
+    # and set prompt character to $
+    # shellcheck disable=SC2016
+    append_to_file "$shell_file" 'precmd () { PS1="${ORANGE}[%~] ${GREEN}$(prompt_ruby_info) ${NORMAL}$ " }'
+    # display directories and files in different colors when running ls
+    append_to_file "$shell_file" 'export CLICOLOR=1;'
+    append_to_file "$shell_file" 'export LSCOLORS=exfxcxdxbxegedabagacad;'
+  else
+    fancy_echo "Skipping prompt customization."
+  fi
+fi
 
 if app_is_installed 'GitHub'; then
   fancy_echo "It looks like you've already configured your GitHub SSH keys."


### PR DESCRIPTION
**Why**:
- The latest version of RVM is causing the script to fail
- chruby is more stable, less intrusive, and more lightweight
- chruby makes it easy to find out what the latest version of Ruby is.
  RVM does not.