### PR TITLE
Don’t use the OS X image on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
-os:
-  - osx
-
 language: sh
 
 before_script:
-  - brew install shellcheck
+  - wget "http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_0.4.4-4_amd64.deb"
+  - sudo dpkg -i "shellcheck_0.4.4-4_amd64.deb"
 
 script:
   - shellcheck mac
-  - bash mac


### PR DESCRIPTION
**Why**:
- It’s super slow
- It’s not a clean OS X image. It comes with a bunch of stuff like XCode, Homebrew, RVM, and other settings we might not want, or things we’re not aware of that can interfere with the script.
- None of the bugs found or reported have been the result of the script failing on Travis.
- It’s more reliable to test changes manually or by having many people use the script and report issues. I also have a spare laptop where I can erase the hard drive and install macOS from scratch.