### PR TITLE
Clean up code around Homebrew Casks

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -12,8 +12,6 @@ brew 'phantomjs'
 
 brew 'hub'
 
-tap 'caskroom/cask'
-tap 'caskroom/versions'
 cask 'flux'
 cask 'github-desktop'
 cask 'sublime-text'

--- a/mac
+++ b/mac
@@ -100,6 +100,10 @@ brew_is_installed() {
   brew list -1 | grep -Fqx "$1"
 }
 
+tap_is_installed() {
+  brew tap -1 | grep -Fqx "$1"
+}
+
 gem_install_or_update() {
   if gem list "$1" | grep "^$1 ("; then
     fancy_echo "Updating %s ..." "$1"
@@ -146,6 +150,9 @@ fi
 # See https://github.com/caskroom/homebrew-cask/releases/tag/v0.60.0
 if brew_is_installed 'brew-cask'; then
   brew uninstall --force 'brew-cask'
+fi
+
+if tap_is_installed 'caskroom/versions'; then
   brew untap caskroom/versions
 fi
 


### PR DESCRIPTION
**Why**:
- We were assuming `caskroom/versions` would be present if `brew-cask` was installed, but that’s not a safe assumption to make.
- tapping `caskroom/cask` and `caskroom/versions` is no longer necessary in Brewfile