### PR TITLE
Fix installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ and once it appears, press `return` to launch it.
 In your Terminal window, copy and paste the command below, then press `return`.
 
 ```sh
-curl -s https://raw.githubusercontent.com/monfresh/laptop/master/laptop | sh -
+bash <(curl -s https://raw.githubusercontent.com/monfresh/laptop/master/laptop)
 ```
 
 The [script](https://github.com/monfresh/laptop/blob/master/mac) itself is

--- a/mac
+++ b/mac
@@ -130,7 +130,7 @@ switch_to_latest_ruby() {
   chruby "ruby-$(latest_installed_ruby)"
 }
 
-append_to_file "$shell_file" "alias laptop='curl -s https://raw.githubusercontent.com/monfresh/laptop/master/laptop | sh -'"
+append_to_file "$shell_file" "alias laptop='bash <(curl -s https://raw.githubusercontent.com/monfresh/laptop/master/laptop)'"
 
 # shellcheck disable=SC2016
 append_to_file "$shell_file" 'export PATH="$HOME/.bin:$PATH"'


### PR DESCRIPTION
Since the `mac` script involves reading from user input, we can't
pipe the curl command to `sh` or `bash` because we would be asking
bash to read from both a file and STDIN.

The solution is to use redirection of STDIN

See: http://unix.stackexchange.com/a/247221