### PR TITLE
Correct "unexpected end of file" in .bash_profile

### DIFF
--- a/mac
+++ b/mac
@@ -117,11 +117,11 @@ gem_install_or_update() {
 app_is_installed() {
   local app_name
   app_name=$(echo "$1" | cut -d'-' -f1)
-  find /Applications -iname "$app_name*" -maxdepth 1 | egrep '.*' > /dev/null
+  find /Applications -iname "$app_name*" -maxdepth 1 | grep -E '.*' > /dev/null
 }
 
 latest_installed_ruby() {
-  find "$HOME/.rubies" -maxdepth 1 -name 'ruby-*' | tail -n1 | egrep -o '\d+\.\d+\.\d+'
+  find "$HOME/.rubies" -maxdepth 1 -name 'ruby-*' | tail -n1 | grep -E -o '\d+\.\d+\.\d+'
 }
 
 switch_to_latest_ruby() {

--- a/mac
+++ b/mac
@@ -262,7 +262,7 @@ EOT
     # display pwd in orange, current ruby version in green,
     # and set prompt character to $
     # shellcheck disable=SC2016
-    append_to_file "$shell_file" 'precmd () { PS1="${ORANGE}[%~] ${GREEN}$(prompt_ruby_info) ${NORMAL}$ " }'
+    append_to_file "$shell_file" 'precmd () { PS1="${ORANGE}[%~] ${GREEN}$(prompt_ruby_info) ${NORMAL}$ " ; }'
     # display directories and files in different colors when running ls
     append_to_file "$shell_file" 'export CLICOLOR=1;'
     append_to_file "$shell_file" 'export LSCOLORS=exfxcxdxbxegedabagacad;'


### PR DESCRIPTION
Running the script on my mac left my `.bash_profile` returning the "unexpected end of file" error. It was fixed as prompted by this SO answer: https://stackoverflow.com/questions/41815171/bash-profile-syntax-error-unexpected-end-of-file