### PR TITLE
Replace hub with gh and remove phantomjs

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -8,9 +8,8 @@ brew 'heroku'
 tap 'homebrew/services'
 brew 'postgresql'
 
-brew 'hub'
+brew 'gh'
 
-cask 'phantomjs'
 cask 'flux'
 cask 'github'
 cask 'sublime-text'

--- a/README.md
+++ b/README.md
@@ -81,13 +81,12 @@ What it sets up
 * [Bundler] for managing Ruby gems
 * [chruby] for managing [Ruby] versions (recommended over RVM and rbenv)
 * [Flux] for adjusting your Mac's display color so you can sleep better
+* [GitHub CLI] brings GitHub to your terminal.
 * [GitHub Desktop] for setting up your SSH keys automatically
 * [Heroku Toolbelt] for deploying and managing Heroku apps
 * [Homebrew] for managing operating system libraries
 * [Homebrew Cask] for quickly installing Mac apps from the command line
 * [Homebrew Services] so you can easily stop, start, and restart services
-* [hub] for interacting with the GitHub API
-* [PhantomJS] for headless website testing
 * [Postgres] for storing relational data
 * [ruby-install] for installing different versions of Ruby
 * [Sublime Text 3] for coding all the things
@@ -96,13 +95,12 @@ What it sets up
 [Bundler]: http://bundler.io/
 [chruby]: https://github.com/postmodern/chruby
 [Flux]: https://justgetflux.com/
+[GitHub CLI]: https://cli.github.com
 [GitHub Desktop]: https://desktop.github.com/
 [Heroku Toolbelt]: https://toolbelt.heroku.com/
 [Homebrew]: http://brew.sh/
 [Homebrew Cask]: http://caskroom.io/
 [Homebrew Services]: https://github.com/Homebrew/homebrew-services
-[hub]: https://github.com/github/hub
-[PhantomJS]: http://phantomjs.org/
 [Postgres]: http://www.postgresql.org/
 [Ruby]: https://www.ruby-lang.org/en/
 [ruby-install]: https://github.com/postmodern/ruby-install

--- a/mac
+++ b/mac
@@ -177,8 +177,6 @@ else
 fi
 
 # shellcheck disable=SC2016
-append_to_file "$shell_file" 'eval "$(hub alias -s)"'
-
 append_to_file "$HOME/.gemrc" 'gem: --no-document'
 
 if command -v rbenv >/dev/null || command -v rvm >/dev/null; then


### PR DESCRIPTION
**Why**:
gh is the new and better official version of the GitHub CLI.

There are better tools for browser testing than PhantomJS these days,
like the `webdrivers`, `ferrum`, and `cuprite` gems. It's no longer
necessary to install a specific tool with Homebrew in order to run
feature/system tests in Ruby.